### PR TITLE
fix/regression: improper signature in init_dropout

### DIFF
--- a/cudnn/src/cudnn.rs
+++ b/cudnn/src/cudnn.rs
@@ -182,7 +182,6 @@ impl Cudnn {
     /// Initializes the parameters and configurations for running CUDA cuDNN dropout operation.
     pub fn init_dropout(
         &self,
-        src_desc: &TensorDescriptor,
         probability : f32,
         seed : u64,
         ) -> Result<DropoutConfig, Error> {


### PR DESCRIPTION
This bug was causing coaster-nn to fail in https://github.com/spearow/coaster-nn/pull/12.