### PR TITLE
feat/version: Bumping bindgen to verson 0.52

### DIFF
--- a/cudnn-sys/Cargo.toml
+++ b/cudnn-sys/Cargo.toml
@@ -20,4 +20,4 @@ libc = "0.2"
 
 [build-dependencies]
 pkg-config = "0.3"
-bindgen = "0.30"
+bindgen = "0.52"


### PR DESCRIPTION
The current version fails to compile for the next nightly rust edition `1.42.0-nightly`, but updating to `bindgen` to `0.52.0`, which is the latest version, fixes issues on nightly and doesn't break the stable version (`1.40.0`)